### PR TITLE
Correções para execução local do gerador

### DIFF
--- a/changelog-ui/.env.example
+++ b/changelog-ui/.env.example
@@ -1,0 +1,3 @@
+# URL do backend da API de changelog
+# Para desenvolvimento local (fora do Docker), copie este arquivo para .env
+API_URL=http://localhost:3000

--- a/changelog-ui/quasar.config.js
+++ b/changelog-ui/quasar.config.js
@@ -14,7 +14,7 @@ const DotEnv = require('dotenv')
 
 
 module.exports = configure(function (/* ctx */) {
-  const parsedEnv = DotEnv.config().parsed
+  const parsedEnv = DotEnv.config().parsed || {}
   return {
     
 
@@ -64,7 +64,7 @@ module.exports = configure(function (/* ctx */) {
       //publicPath: '.',
        publicPath: process.env.NODE_ENV == "development" ? '' : parsedEnv.DOMAIN_NAME,
       // analyze: true,
-       env: parsedEnv,
+       env: { API_URL: process.env.API_URL, ...parsedEnv },
       // rawDefine: {}
       // ignorePublicFolder: true,
       // minify: false,

--- a/changelog-ui/src/pages/ChangeLog/FormularioChangeLog.vue
+++ b/changelog-ui/src/pages/ChangeLog/FormularioChangeLog.vue
@@ -361,7 +361,7 @@ export default defineComponent({
       this.validations(changeLog);
 
       axios
-        .post(process.env.API_URL || "", changeLog)
+        .post(`${process.env.API_URL || ""}/change-log/generate-change-log`, changeLog)
         .then((response: any) => {
           this.infoApiChanges = response.data.obj || response.data;
         })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,5 @@ services:
       dockerfile: Dockerfile
     ports:
       - "9000:9000"
+    environment:
+      - API_URL=http://localhost:3000


### PR DESCRIPTION
### Problema
- Tentativas de executar o repositório da maneira que está descrita no readme resulta em um 404 durante o envio do formulário da UI para o backend.


### O que foi alterado?
- Corrigido o endpoint utilizado pelo formulário:
Na falta de um arquivo de configuração de ambiente (.env), o serviço do front não consegue rotear corretamente a chamada. A necessidade foi removida ao adicionar um novo parametro ao dockerfile para considerar o API_URL apontando para o backend desde a criação das imagens do container. Além disso também foi adicionado o path completo para acesso ao endpoint do backend dentro do formulário.


### Importância
- Sem esse ajuste, desenvolvedores que seguirem apenas o descrito no readme não conseguirão utilizar a aplicação sem precisar realizar um debug por conta própria.